### PR TITLE
feat: Add centralized IP address registry and module (closes #22)

### DIFF
--- a/config/network_addressing.json
+++ b/config/network_addressing.json
@@ -1,0 +1,41 @@
+{
+  "subnet": "192.168.100.0/24",
+  "subnet_prefix": "192.168.100",
+  "gateway": "192.168.100.1",
+  "services": {
+    "fl_server": {
+      "ip": "192.168.100.10",
+      "port": 8080,
+      "range": "192.168.100.10-19"
+    },
+    "policy_engine": {
+      "ip": "192.168.100.20",
+      "port": 5000,
+      "range": "192.168.100.20-29"
+    },
+    "collector": {
+      "ip": "192.168.100.40",
+      "port": 8000,
+      "range": "192.168.100.40-49"
+    },
+    "sdn_controller": {
+      "ip": "192.168.100.41",
+      "ports": [6633, 8181],
+      "range": "192.168.100.30-49"
+    },
+    "openvswitch": {
+      "base_ip": "192.168.100.60",
+      "range": "192.168.100.60-99"
+    },
+    "fl_clients": {
+      "base_ip": "192.168.100.101",
+      "range": "192.168.100.100-255",
+      "max_clients": 155
+    }
+  },
+  "gns3": {
+    "vm_ip": "192.168.141.128",
+    "api_port": 3080,
+    "note": "User must configure this for their environment"
+  }
+}

--- a/src/core/config/network_addressing.py
+++ b/src/core/config/network_addressing.py
@@ -1,0 +1,48 @@
+import json
+import os
+from typing import Dict, Any, Optional
+
+class NetworkAddressing:
+    """Centralized network IP address management."""
+    
+    _instance = None
+    _config_path = "config/network_addressing.json"
+    
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._load_config()
+        return cls._instance
+    
+    def _load_config(self):
+        """Load network addressing configuration."""
+        config_path = os.getenv('NETWORK_CONFIG', self._config_path)
+        with open(config_path, 'r') as f:
+            self.config = json.load(f)
+    
+    def get_service_ip(self, service_name: str) -> str:
+        """Get IP address for a service."""
+        return self.config['services'][service_name]['ip']
+    
+    def get_service_port(self, service_name: str) -> int:
+        """Get port for a service."""
+        return self.config['services'][service_name]['port']
+    
+    def get_service_url(self, service_name: str, protocol: str = 'http') -> str:
+        """Get full URL for a service."""
+        ip = self.get_service_ip(service_name)
+        port = self.get_service_port(service_name)
+        return f"{protocol}://{ip}:{port}"
+    
+    def get_client_ip(self, client_id: int) -> str:
+        """Generate FL client IP address."""
+        base_ip = self.config['services']['fl_clients']['base_ip']
+        base = int(base_ip.split('.')[-1])
+        return f"{self.config['subnet_prefix']}.{base + client_id - 1}"
+    
+    def get_subnet(self) -> str:
+        """Get subnet CIDR."""
+        return self.config['subnet']
+
+# Global instance
+network_addressing = NetworkAddressing()


### PR DESCRIPTION
### Summary
This PR implements Part 1 of the IP Address Centralization enhancement (closes #22).

It introduces the foundation for managing network addresses from a single source of truth.

### Changes
* **Added `config/network_addressing.json`:** A new configuration file that defines all service IPs, ports, and ranges for the project.
* **Added `src/core/config/network_addressing.py`:** A new `NetworkAddressing` singleton class that loads the JSON config and provides helper methods (`get_service_ip`, `get_service_url`, `get_client_ip`) for other modules to use.

### Testing
Verified the module locally. The new class successfully loads the JSON file and returns the correct values:

* **Subnet:** `192.168.100.0/24`
* **FL Server URL:** `http://192.168.100.10:8080`
* **Policy Engine URL:** `http://192.168.100.20:5000`
* **FL Client #3 IP:** `192.168.100.103`

This PR lays the groundwork for Part 2 and Part 3.